### PR TITLE
feat(route53): support hosted zone DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_route53_zone.route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_route53_record.route53_records](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.route53_zones](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 
 ## Inputs
 
@@ -35,5 +36,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_hosted_zones"></a> [hosted\_zones](#output\_hosted\_zones) | n/a |
+| <a name="output_hosted_zones"></a> [hosted\_zones](#output\_hosted\_zones) | Collection of all route53 zones and child attributes |
+| <a name="output_hosted_zones_records"></a> [hosted\_zones\_records](#output\_hosted\_zones\_records) | Collection of all route53 zones DNS records |
 <!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,13 @@
 locals {
   route53_zones = { for zone in var.route53_zones : "${zone.name}-${zone.type}" => zone }
+  route53_zone_records = {
+    for record in flatten(
+      [
+        for zone in var.route53_zones :
+        [
+          for dns_record in zone.dns_records : merge({ "zone_record_name" = "${zone.name}-${zone.type}" }, dns_record)
+        ]
+      ]
+    ) : "${record.domain_name}_${record.record_type}" => record
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_zone" "route53_zone" {
+resource "aws_route53_zone" "route53_zones" {
   for_each = local.route53_zones
 
   name          = each.value.name
@@ -12,3 +12,14 @@ resource "aws_route53_zone" "route53_zone" {
     }
   }
 }
+
+resource "aws_route53_record" "route53_records" {
+  for_each = local.route53_zone_records
+
+  zone_id = aws_route53_zone.route53_zones[each.value.zone_record_name].id
+  name    = each.value.domain_name
+  type    = each.value.record_type
+  ttl     = each.value.ttl
+  records = each.value.records
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,9 @@
 output "hosted_zones" {
-  value = aws_route53_zone.route53_zone
+  value = aws_route53_zone.route53_zones
+  description = "Collection of all route53 zones and child attributes"
+}
+
+output "hosted_zones_records" {
+  value = aws_route53_record.route53_records
+  description = "Collection of all route53 zones DNS records"
 }


### PR DESCRIPTION
add resource block to support creating route53 hosted… zone dns records.

loop over hosted zone inputs and build unique collection of records for zone

Signed-off-by: kolvin <15124052+Kolvin@users.noreply.github.com>